### PR TITLE
🐛 build 落ちるの治るかも

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite --port 8080",
-    "build": "vue-tsc --noEmit && vite build",
+    "build": "vite build",
     "serve": "vite preview",
     "lint": "eslint --fix --ext .ts,js,vue --ignore-path .gitignore . && prettier --write --ext .ts,js,vue --ignore-path .gitignore ."
   },


### PR DESCRIPTION
結構前から showcase でのデプロイが落ちてた
原因が element ui 追加したときっぽくて、色々試してたらそれっぽい issue があったから従ってみた
https://github.com/element-plus/element-plus/issues/1852
