### PR TITLE
♻️ component を `kebab-case` から `PascalCase` にした

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
-  <layout>
+  <Layout>
     <router-view />
-  </layout>
+  </Layout>
 </template>
 
 <script lang="ts">

--- a/src/layout/Layout.vue
+++ b/src/layout/Layout.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <el-container class="layout-container">
-      <layout-header />
+      <LayoutHeader />
       <!-- <el-header class="header-container"> header </el-header> -->
       <el-container>
         <el-aside>


### PR DESCRIPTION
一部 `kebab-case` になってたのを `PascalCase` に統一した
参考: https://v3.ja.vuejs.org/style-guide/#テンプレート内でのコンポーネント名の形式-強く推奨
